### PR TITLE
feat(react): add `preserveElementProps`

### DIFF
--- a/packages/react/src/create-component.ts
+++ b/packages/react/src/create-component.ts
@@ -106,6 +106,7 @@ export interface Options<I extends HTMLElement, E extends EventNames = {}> {
   elementClass: Constructor<I>;
   events?: E;
   displayName?: string;
+  preserveElementProps?: boolean;
 }
 
 type Constructor<T> = {new (): T};
@@ -213,6 +214,8 @@ const setProperty = <E extends Element>(
  * @param options.displayName A React component display name, used in debugging
  * messages. Default value is inferred from the name of custom element class
  * registered via `customElements.define`.
+ * @param options.preserveElementProps A boolean to determine if the React props
+ * should be preserved on the custom element.
  */
 export const createComponent = <
   I extends HTMLElement,
@@ -223,6 +226,7 @@ export const createComponent = <
   elementClass,
   events,
   displayName,
+  preserveElementProps,
 }: Options<I, E>): ReactWebComponent<I, E> => {
   const eventProps = new Set(Object.keys(events ?? {}));
 
@@ -323,6 +327,7 @@ export const createComponent = <
     }
 
     return React.createElement(tagName, {
+      ...(preserveElementProps ? elementProps : {}),
       ...reactProps,
       ref: React.useCallback(
         (node: I) => {


### PR DESCRIPTION
## Summary of Changes
<!-- Enter Summary Below -->
Previously, if a Web Component cloned nodes, any props passed with the
wrapper were lost and the component went back into the default state.
This will commit will allow authors to pass an optional prop to preserve
the original attributes.

### Related Issues
<!-- Enter GitHub Issue Number or Jira Ticket URL Below -->
https://github.com/LeaseQuery/LQ.Stellar.ComponentLibrary/issues/416

### How has this change been tested?
**Browser Testing**
- [ ] Blink (_Chrome/Edge/Opera/Brave_)
- [ ] Gecko (_Firefox_)
- [ ] WebKit (_Safari_)
- [x] N/A - Browser testing not required

**Screen Reader Testing**
- [ ] Narrator for Windows
- [ ] VoiceOver for Mac
- [x] N/A - Screen reader testing not required

### Screenshots
| Before | After |
| ------ | ----- |
| N/A | N/A |