### PR TITLE
chore(react): adjust build info for @LeaseQuery fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@
 >
 > See https://github.com/LeaseQuery/LQ.Stellar.ComponentLibrary/issues/416 for
 > more details.
+>
+> **How to Build**
+>
+> 1. After making changes to the package (presumably in `packages/react`),
+>    manually increment the version in `packages/react/package.json`.
+> 2. Run `$ npm build` in the root of the repo.
+> 3. Run `$ npm publish` in the `packages/react` directory.
 
 ---
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@lit/react",
-  "version": "1.0.6",
+  "name": "@leasequery/lit-react",
+  "version": "0.0.1",
   "description": "A React component wrapper for web components.",
   "license": "BSD-3-Clause",
   "homepage": "https://lit.dev/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lit/lit.git",
+    "url": "https://github.com/LeaseQuery/lit",
     "directory": "packages/react"
   },
   "type": "module",
@@ -199,6 +199,6 @@
     "@types/react": "17 || 18"
   },
   "publishConfig": {
-    "access": "public"
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -38,6 +38,7 @@ const PACKAGE_CLASS_PREFIXES = {
   '@lit/context': '_$Q',
   '@lit/react': '_$R',
   '@lit-labs/signals': '_$S',
+  '@leasequery/lit-react': '_$T',
 };
 
 // Validate prefix uniqueness


### PR DESCRIPTION
Rename the React package to `@leasequery/lit-react`, add it to `rollup-common.js`, and update `README.md` with build instructions

Refs: https://github.com/LeaseQuery/LQ.Stellar.ComponentLibrary/issues/416