### PR TITLE
fix(react): ensure events aren't overwritten

### DIFF
--- a/packages/react/src/create-component.ts
+++ b/packages/react/src/create-component.ts
@@ -265,8 +265,16 @@ export const createComponent = <
         continue;
       }
 
-      if (eventProps.has(k) || k in elementClass.prototype) {
+      if (eventProps.has(k)) {
         elementProps[k] = v;
+        continue;
+      }
+
+      if (k in elementClass.prototype) {
+        elementProps[k] = v;
+        if (preserveElementProps) {
+          reactProps[k] = v;
+        }
         continue;
       }
 
@@ -327,7 +335,6 @@ export const createComponent = <
     }
 
     return React.createElement(tagName, {
-      ...(preserveElementProps ? elementProps : {}),
       ...reactProps,
       ref: React.useCallback(
         (node: I) => {


### PR DESCRIPTION
Instead of sending `elementProps` to `React.createElement`, add the props to `reactProps` if `preserveElementProps` is enabled.

Refs: https://github.com/LeaseQuery/LQ.Stellar.ComponentLibrary/issues/424