### PR TITLE
feat(react-finquery-fork): add preserveElementProps

### DIFF
--- a/.changeset/lazy-kids-battle.md
+++ b/.changeset/lazy-kids-battle.md
@@ -1,0 +1,5 @@
+---
+'@leasequery/lit-react': minor
+---
+
+forked the repo and added ability to preserve element props

--- a/.eslintignore
+++ b/.eslintignore
@@ -139,6 +139,14 @@ packages/react/index.*
 packages/react/create-component.*
 packages/react/use-controller.*
 
+packages/react-finquery-fork/development/
+packages/react-finquery-fork/node/
+packages/react-finquery-fork/test/
+packages/react-finquery-fork/node_modules/
+packages/react-finquery-fork/index.*
+packages/react-finquery-fork/create-component.*
+packages/react-finquery-fork/use-controller.*
+
 packages/reactive-element/decorators/
 packages/reactive-element/development/
 packages/reactive-element/legacy-decorators/

--- a/.prettierignore
+++ b/.prettierignore
@@ -125,6 +125,14 @@ packages/react/index.*
 packages/react/create-component.*
 packages/react/use-controller.*
 
+packages/react-finquery-fork/development/
+packages/react-finquery-fork/node/
+packages/react-finquery-fork/test/
+packages/react-finquery-fork/node_modules/
+packages/react-finquery-fork/index.*
+packages/react-finquery-fork/create-component.*
+packages/react-finquery-fork/use-controller.*
+
 packages/reactive-element/decorators/
 packages/reactive-element/development/
 packages/reactive-element/legacy-decorators/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@
 
 </div>
 
+---
+
+> [!IMPORTANT]
+>
+> **FORKED REPO NOTICE**
+>
+> This repo was forked from https://github.com/lit/lit to make adjustments to
+> the `packages/react` wrapper by creating a new package,
+> `packages/react-finquery-fork`.
+>
+> See https://github.com/LeaseQuery/LQ.Stellar.ComponentLibrary/issues/416 for
+> more details.
+>
+> **How to Build**
+>
+> 1. After making changes to the package (presumably in
+>    `packages/react-finquery-fork`), manually increment the version in
+>    `packages/react-finquery-fork/package.json`.
+> 2. Run `$ npm changeset` and follow the CLI prompts.
+> 3. Commit changes (amends are fine).
+> 4. Run `$ npm run build` in the root of the repo.
+> 5. Run `$ npm publish` in the `packages/react-finquery-fork` directory.
+
+---
+
 Lit is a simple library for building fast, lightweight web components.
 
 At Lit's core is a boilerplate-killing component base class that provides reactive state, scoped styles, and a declarative template system that's tiny, fast and expressive.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6290,6 +6290,10 @@
         "node": ">= 12"
       }
     },
+    "node_modules/@leasequery/lit-react": {
+      "resolved": "packages/react-finquery-fork",
+      "link": true
+    },
     "node_modules/@lit-examples/nextjs-v13": {
       "resolved": "examples/nextjs-v13",
       "link": true
@@ -31853,6 +31857,23 @@
     "packages/react": {
       "name": "@lit/react",
       "version": "1.0.6",
+      "license": "BSD-3-Clause",
+      "devDependencies": {
+        "@lit-internal/scripts": "^1.0.1",
+        "@lit/reactive-element": "^2.0.4",
+        "@types/react-dom": "^18.2.6",
+        "@types/trusted-types": "^2.0.2",
+        "@web/dev-server-rollup": "^0.5.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
+    },
+    "packages/react-finquery-fork": {
+      "name": "@leasequery/lit-react",
+      "version": "0.1.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@lit-internal/scripts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "./packages/reactive-element:build",
         "./packages/context:build",
         "./packages/react:build",
+        "./packages/react-finquery-fork:build",
         "./packages/task:build",
         "./packages/tests:build",
         "./packages/ts-transformers:build",

--- a/packages/react-finquery-fork/.gitignore
+++ b/packages/react-finquery-fork/.gitignore
@@ -1,0 +1,7 @@
+/development/
+/node/
+/test/
+/node_modules/
+/index.*
+/create-component.*
+/use-controller.*

--- a/packages/react-finquery-fork/README.md
+++ b/packages/react-finquery-fork/README.md
@@ -1,0 +1,20 @@
+# @leasequery/lit-react
+
+Forked version of `@lit/react`
+
+## Overview
+
+## `createComponent`
+
+Forked to preserve custom element attributes when `lit` components clone their
+nodes.
+
+See `@lit/react` for more information.
+
+## Installation
+
+From inside your project folder, run:
+
+```bash
+$ npm install @leasequery/lit-react
+```

--- a/packages/react-finquery-fork/package.json
+++ b/packages/react-finquery-fork/package.json
@@ -1,0 +1,189 @@
+{
+  "name": "@leasequery/lit-react",
+  "version": "0.1.0",
+  "description": "A React component wrapper for web components.",
+  "license": "BSD-3-Clause",
+  "homepage": "https://lit.dev/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LeaseQuery/lit",
+    "directory": "packages/react"
+  },
+  "type": "module",
+  "main": "index.js",
+  "module": "index.js",
+  "typings": "index.d.ts",
+  "directories": {
+    "test": "test"
+  },
+  "exports": {
+    ".": {
+      "types": "./development/index.d.ts",
+      "browser": {
+        "development": "./development/index.js",
+        "default": "./index.js"
+      },
+      "node": {
+        "development": "./node/development/index.js",
+        "default": "./node/index.js"
+      },
+      "development": "./development/index.js",
+      "default": "./index.js"
+    }
+  },
+  "files": [
+    "/development/",
+    "!/development/test/",
+    "/node/",
+    "/index.{d.ts,d.ts.map,js,js.map}",
+    "/create-component.{d.ts,d.ts.map,js,js.map}"
+  ],
+  "scripts": {
+    "build": "wireit",
+    "build:ts": "wireit",
+    "build:ts:types": "wireit",
+    "build:rollup": "wireit",
+    "test": "wireit",
+    "test:dev": "wireit",
+    "test:prod": "wireit",
+    "test:node": "wireit",
+    "checksize": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "build:rollup",
+        "build:ts",
+        "build:ts:types"
+      ]
+    },
+    "build:ts": {
+      "command": "tsc --build --pretty",
+      "dependencies": [
+        "../reactive-element:build:ts:types"
+      ],
+      "clean": "if-file-deleted",
+      "files": [
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "tsconfig.json"
+      ],
+      "output": [
+        "development",
+        "tsconfig.tsbuildinfo"
+      ]
+    },
+    "build:ts:types": {
+      "command": "treemirror development . \"**/*.d.ts{,.map}\" \"!test\"",
+      "dependencies": [
+        "../internal-scripts:build",
+        "build:ts"
+      ],
+      "files": [],
+      "output": [
+        "*.d.ts{,.map}"
+      ]
+    },
+    "build:rollup": {
+      "command": "rollup -c",
+      "dependencies": [
+        "build:ts",
+        "../..:rollup-config"
+      ],
+      "files": [
+        "rollup.config.js",
+        "../../../rollup-common.js"
+      ],
+      "output": [
+        "create-component.js{,.map}",
+        "index.js{,.map}",
+        "node/**/*.js{,.map}"
+      ]
+    },
+    "checksize": {
+      "command": "rollup -c --environment=CHECKSIZE",
+      "dependencies": [
+        "build:ts",
+        "../..:rollup-config"
+      ],
+      "files": [
+        "rollup.config.js",
+        "../../../rollup-common.js"
+      ],
+      "output": []
+    },
+    "test": {
+      "dependencies": [
+        "test:dev",
+        "test:prod",
+        "test:node"
+      ]
+    },
+    "test:dev": {
+      "#comment": "Test files must also be specified in web-test-runner.config.js rollup config",
+      "command": "node ../tests/run-web-tests.js \"development/**/*_test.js\" --config web-test-runner.config.js",
+      "dependencies": [
+        "build:ts",
+        "build:rollup",
+        "../reactive-element:build",
+        "../tests:build"
+      ],
+      "env": {
+        "BROWSERS": {
+          "external": true
+        },
+        "MODE": "dev"
+      },
+      "files": [
+        "web-test-runner.config.js"
+      ],
+      "output": []
+    },
+    "test:prod": {
+      "#comment": "Test files must also be specified in web-test-runner.config.js rollup config",
+      "command": "node ../tests/run-web-tests.js \"development/**/*_test.js\" --config web-test-runner.config.js",
+      "dependencies": [
+        "build:ts",
+        "build:rollup",
+        "../reactive-element:build",
+        "../tests:build"
+      ],
+      "env": {
+        "BROWSERS": {
+          "external": true
+        },
+        "MODE": "prod"
+      },
+      "files": [
+        "web-test-runner.config.js"
+      ],
+      "output": []
+    },
+    "test:node": {
+      "command": "node development/test/node-render.js",
+      "dependencies": [
+        "build:ts",
+        "build:rollup",
+        "../reactive-element:build"
+      ],
+      "files": [],
+      "output": []
+    }
+  },
+  "author": "Google LLC",
+  "devDependencies": {
+    "@lit/reactive-element": "^2.0.4",
+    "@lit-internal/scripts": "^1.0.1",
+    "@types/react-dom": "^18.2.6",
+    "@types/trusted-types": "^2.0.2",
+    "@web/dev-server-rollup": "^0.5.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "peerDependencies": {
+    "@types/react": "17 || 18 || 19"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  }
+}

--- a/packages/react-finquery-fork/rollup.config.js
+++ b/packages/react-finquery-fork/rollup.config.js
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {litProdConfig} from '../../rollup-common.js';
+import {createRequire} from 'module';
+
+export default litProdConfig({
+  packageName: createRequire(import.meta.url)('./package.json').name,
+  entryPoints: ['index', 'create-component'],
+  includeNodeBuild: true,
+});

--- a/packages/react-finquery-fork/src/create-component.ts
+++ b/packages/react-finquery-fork/src/create-component.ts
@@ -1,0 +1,356 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type React from 'react';
+
+const NODE_MODE = false;
+const DEV_MODE = true;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DistributiveOmit<T, K extends string | number | symbol> = T extends any
+  ? K extends keyof T
+    ? Omit<T, K>
+    : T
+  : T;
+type PropsWithoutRef<T> = DistributiveOmit<T, 'ref'>;
+
+/**
+ * Creates a type to be used for the props of a web component used directly in
+ * React JSX.
+ *
+ * Example:
+ *
+ * ```ts
+ * declare module "react" {
+ *   namespace JSX {
+ *     interface IntrinsicElements {
+ *       'x-foo': WebComponentProps<XFoo>;
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export type WebComponentProps<I extends HTMLElement> = React.DetailedHTMLProps<
+  React.HTMLAttributes<I>,
+  I
+> &
+  ElementProps<I>;
+
+/**
+ * Type of the React component wrapping the web component. This is the return
+ * type of `createComponent`.
+ */
+export type ReactWebComponent<
+  I extends HTMLElement,
+  E extends EventNames = {},
+> = React.ForwardRefExoticComponent<
+  // TODO(augustjk): Remove and use `React.PropsWithoutRef` when
+  // https://github.com/preactjs/preact/issues/4124 is fixed.
+  PropsWithoutRef<ComponentProps<I, E>> & React.RefAttributes<I>
+>;
+
+// Props derived from custom element class. Currently has limitations of making
+// all properties optional and also surfaces life cycle methods in autocomplete.
+// TODO(augustjk) Consider omitting keyof LitElement to remove "internal"
+// lifecycle methods or allow user to explicitly provide props.
+type ElementProps<I> = Partial<Omit<I, keyof HTMLElement>>;
+
+// Acceptable props to the React component.
+type ComponentProps<I, E extends EventNames = {}> = Omit<
+  React.HTMLAttributes<I>,
+  // Prefer type of provided event handler props or those on element over
+  // built-in HTMLAttributes
+  keyof E | keyof ElementProps<I>
+> &
+  EventListeners<E> &
+  ElementProps<I>;
+
+/**
+ * Type used to cast an event name with an event type when providing the
+ * `events` option to `createComponent` for better typing of the event handler
+ * prop.
+ *
+ * Example:
+ *
+ * ```ts
+ * const FooComponent = createComponent({
+ *   ...
+ *   events: {
+ *     onfoo: 'foo' as EventName<FooEvent>,
+ *   }
+ * });
+ * ```
+ *
+ * `onfoo` prop will have the type `(e: FooEvent) => void`.
+ */
+export type EventName<T extends Event = Event> = string & {
+  __eventType: T;
+};
+
+// A key value map matching React prop names to event names.
+type EventNames = Record<string, EventName | string>;
+
+// A map of expected event listener types based on EventNames.
+type EventListeners<R extends EventNames> = {
+  [K in keyof R]?: R[K] extends EventName
+    ? (e: R[K]['__eventType']) => void
+    : (e: Event) => void;
+};
+
+export interface Options<I extends HTMLElement, E extends EventNames = {}> {
+  react: typeof React;
+  tagName: string;
+  elementClass: Constructor<I>;
+  events?: E;
+  displayName?: string;
+  preserveElementProps?: boolean;
+}
+
+type Constructor<T> = {new (): T};
+
+const reservedReactProperties = new Set([
+  'children',
+  'localName',
+  'ref',
+  'style',
+  'className',
+]);
+
+const listenedEvents = new WeakMap<Element, Map<string, EventListenerObject>>();
+
+/**
+ * Adds an event listener for the specified event to the given node. In the
+ * React setup, there should only ever be one event listener. Thus, for
+ * efficiency only one listener is added and the handler for that listener is
+ * updated to point to the given listener function.
+ */
+const addOrUpdateEventListener = (
+  node: Element,
+  event: string,
+  listener: (event?: Event) => void
+) => {
+  let events = listenedEvents.get(node);
+  if (events === undefined) {
+    listenedEvents.set(node, (events = new Map()));
+  }
+  let handler = events.get(event);
+  if (listener !== undefined) {
+    // If necessary, add listener and track handler
+    if (handler === undefined) {
+      events.set(event, (handler = {handleEvent: listener}));
+      node.addEventListener(event, handler);
+      // Otherwise just update the listener with new value
+    } else {
+      handler.handleEvent = listener;
+    }
+    // Remove listener if one exists and value is undefined
+  } else if (handler !== undefined) {
+    events.delete(event);
+    node.removeEventListener(event, handler);
+  }
+};
+
+/**
+ * Sets properties and events on custom elements. These properties and events
+ * have been pre-filtered so we know they should apply to the custom element.
+ */
+const setProperty = <E extends Element>(
+  node: E,
+  name: string,
+  value: unknown,
+  old: unknown,
+  events?: EventNames
+) => {
+  const event = events?.[name];
+  // Dirty check event value.
+  if (event !== undefined) {
+    if (value !== old) {
+      addOrUpdateEventListener(node, event, value as (e?: Event) => void);
+    }
+    return;
+  }
+  // But don't dirty check properties; elements are assumed to do this.
+  node[name as keyof E] = value as E[keyof E];
+
+  // This block is to replicate React's behavior for attributes of native
+  // elements where `undefined` or `null` values result in attributes being
+  // removed.
+  // https://github.com/facebook/react/blob/899cb95f52cc83ab5ca1eb1e268c909d3f0961e7/packages/react-dom-bindings/src/client/DOMPropertyOperations.js#L107-L141
+  //
+  // It's only needed here for native HTMLElement properties that reflect
+  // attributes of the same name but don't have that behavior like "id" or
+  // "draggable".
+  if (
+    (value === undefined || value === null) &&
+    name in HTMLElement.prototype
+  ) {
+    node.removeAttribute(name);
+  }
+};
+
+/**
+ * Creates a React component for a custom element. Properties are distinguished
+ * from attributes automatically, and events can be configured so they are added
+ * to the custom element as event listeners.
+ *
+ * @param options An options bag containing the parameters needed to generate a
+ * wrapped web component.
+ *
+ * @param options.react The React module, typically imported from the `react`
+ * npm package.
+ * @param options.tagName The custom element tag name registered via
+ * `customElements.define`.
+ * @param options.elementClass The custom element class registered via
+ * `customElements.define`.
+ * @param options.events An object listing events to which the component can
+ * listen. The object keys are the event property names passed in via React
+ * props and the object values are the names of the corresponding events
+ * generated by the custom element. For example, given `{onactivate:
+ * 'activate'}` an event function may be passed via the component's `onactivate`
+ * prop and will be called when the custom element fires its `activate` event.
+ * @param options.displayName A React component display name, used in debugging
+ * messages. Default value is inferred from the name of custom element class
+ * registered via `customElements.define`.
+ * @param [options.preserveElementProps] A boolean to determine if the React
+ * props should be preserved on the custom element.
+ */
+export const createComponent = <
+  I extends HTMLElement,
+  E extends EventNames = {},
+>({
+  react: React,
+  tagName,
+  elementClass,
+  events,
+  displayName,
+  preserveElementProps,
+}: Options<I, E>): ReactWebComponent<I, E> => {
+  const eventProps = new Set(Object.keys(events ?? {}));
+
+  if (DEV_MODE && !NODE_MODE) {
+    for (const p of reservedReactProperties) {
+      if (p in elementClass.prototype && !(p in HTMLElement.prototype)) {
+        // Note, this effectively warns only for `ref` since the other
+        // reserved props are on HTMLElement.prototype. To address this
+        // would require crawling down the prototype, which doesn't feel worth
+        // it since implementing these properties on an element is extremely
+        // rare.
+        console.warn(
+          `${tagName} contains property ${p} which is a React reserved ` +
+            `property. It will be used by React and not set on the element.`
+        );
+      }
+    }
+  }
+
+  type Props = ComponentProps<I, E>;
+
+  const ReactComponent = React.forwardRef<I, Props>((props, ref) => {
+    const prevElemPropsRef = React.useRef(new Map());
+    const elementRef = React.useRef<I | null>(null);
+
+    // Props to be passed to React.createElement
+    const reactProps: Record<string, unknown> = {};
+    // Props to be set on element with setProperty
+    const elementProps: Record<string, unknown> = {};
+
+    for (const [k, v] of Object.entries(props)) {
+      if (reservedReactProperties.has(k)) {
+        // React does *not* handle `className` for custom elements so
+        // coerce it to `class` so it's handled correctly.
+        reactProps[k === 'className' ? 'class' : k] = v;
+        continue;
+      }
+
+      if (eventProps.has(k)) {
+        elementProps[k] = v;
+        continue;
+      }
+
+      if (k in elementClass.prototype) {
+        elementProps[k] = v;
+        if (preserveElementProps) {
+          reactProps[k] = v;
+        }
+        continue;
+      }
+
+      reactProps[k] = v;
+    }
+
+    // useLayoutEffect produces warnings during server rendering.
+    if (!NODE_MODE) {
+      // This one has no dependency array so it'll run on every re-render.
+      React.useLayoutEffect(() => {
+        if (elementRef.current === null) {
+          return;
+        }
+        const newElemProps = new Map();
+        for (const key in elementProps) {
+          setProperty(
+            elementRef.current,
+            key,
+            props[key],
+            prevElemPropsRef.current.get(key),
+            events
+          );
+          prevElemPropsRef.current.delete(key);
+          newElemProps.set(key, props[key]);
+        }
+        // "Unset" any props from previous render that no longer exist.
+        // Setting to `undefined` seems like the correct thing to "unset"
+        // but currently React will set it as `null`.
+        // See https://github.com/facebook/react/issues/28203
+        for (const [key, value] of prevElemPropsRef.current) {
+          setProperty(elementRef.current, key, undefined, value, events);
+        }
+        prevElemPropsRef.current = newElemProps;
+      });
+
+      // Empty dependency array so this will only run once after first render.
+      React.useLayoutEffect(() => {
+        elementRef.current?.removeAttribute('defer-hydration');
+      }, []);
+    }
+
+    if (NODE_MODE) {
+      // If component is to be server rendered with `@lit/ssr-react`, pass
+      // element properties in a special bag to be set by the server-side
+      // element renderer.
+      if (
+        (React.createElement.name === 'litPatchedCreateElement' ||
+          globalThis.litSsrReactEnabled) &&
+        Object.keys(elementProps).length
+      ) {
+        // This property needs to remain unminified.
+        reactProps['_$litProps$'] = elementProps;
+      }
+    } else {
+      // Suppress hydration warning for server-rendered attributes.
+      // This property needs to remain unminified.
+      reactProps['suppressHydrationWarning'] = true;
+    }
+
+    return React.createElement(tagName, {
+      ...reactProps,
+      ref: React.useCallback(
+        (node: I) => {
+          elementRef.current = node;
+          if (typeof ref === 'function') {
+            ref(node);
+          } else if (ref !== null) {
+            ref.current = node;
+          }
+        },
+        [ref]
+      ),
+    });
+  });
+
+  ReactComponent.displayName = displayName ?? elementClass.name;
+
+  return ReactComponent;
+};

--- a/packages/react-finquery-fork/src/env.d.ts
+++ b/packages/react-finquery-fork/src/env.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// eslint-disable-next-line no-var
+declare var litSsrReactEnabled: undefined | boolean;

--- a/packages/react-finquery-fork/src/index.ts
+++ b/packages/react-finquery-fork/src/index.ts
@@ -1,0 +1,1 @@
+export * from './create-component.js';

--- a/packages/react-finquery-fork/tsconfig.json
+++ b/packages/react-finquery-fork/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "es2021",
+    "module": "NodeNext",
+    "lib": ["es2021", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "outDir": "./development/",
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "moduleResolution": "NodeNext",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "jsx": "react",
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "types": ["mocha"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": []
+}

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -38,6 +38,7 @@ const PACKAGE_CLASS_PREFIXES = {
   '@lit/context': '_$Q',
   '@lit/react': '_$R',
   '@lit-labs/signals': '_$S',
+  '@leasequery/lit-react': '_$T',
 };
 
 // Validate prefix uniqueness


### PR DESCRIPTION
Fork the repo and copy `@lit/react`'s `create-component` file

Previously, if a Web Component cloned nodes, any props passed with the
wrapper were lost and the component went back into the default state.
This will commit will allow authors to pass an optional prop to preserve
the original attributes.

This commit squashes all previous changes into one for easier
maintenance

Refs: https://github.com/LeaseQuery/LQ.Stellar.ComponentLibrary/issues/416
Refs: https://github.com/LeaseQuery/LQ.Stellar.ComponentLibrary/issues/424